### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           dockerfile: Dockerfile
           name: ${{ secrets.DOCKERHUB_NAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore